### PR TITLE
fix pcre2-10.23.zip download url

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -51,7 +51,7 @@ if [ "x${HAVE_PCRE2}" = "xno" ]; then
   # Prepare pcre2-10.23 source:
   (mkdir -p "${WORKDIR}/thirdparty/" && \
     cd "${WORKDIR}/thirdparty" && \
-    wget "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.23.zip"
+    wget "ftp://ftp.pcre.org/pub/pcre/pcre2-10.23.zip"
     echo "56c07f59ccd052ccdbdedadf24574a63  pcre2-10.23.zip" | md5sum -c || exit 1
     unzip "pcre2-10.23.zip" && \
     cd "pcre2-10.23" && \


### PR DESCRIPTION
download pcre2-10.23.zip from pcre.org 

fix the issue for ftp.csx.cam.ac.uk being unavailable 

```Resolving ftp.csx.cam.ac.uk (ftp.csx.cam.ac.uk)... 131.111.8.115
Connecting to ftp.csx.cam.ac.uk (ftp.csx.cam.ac.uk)|131.111.8.115|:21... failed: Connection timed out.```